### PR TITLE
docs: OCI packaging (dockworker) and component stack deploy model

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -132,8 +132,9 @@ struct AgentRun {
 - Zero-Trust OIDC for all operations
 
 **Deployment**:
-- Nix flakes for reproducible builds (lornu.ai pattern)
-- Attic/R2 caching for binaries
+- **No Dockerfiles** — OCI images from Nix (`dockerTools.buildLayeredImage`) + **[dockworker.ai](https://dockworker.ai)** (`dockworker.toml` → skopeo push to `ghcr.io`)
+- Per-component `deploy/` (Kustomize + GKE Autopilot overlays); OGRE composes the stack ([docs/DEPLOY_STACK.md](./docs/DEPLOY_STACK.md), [docs/PACKAGING.md](./docs/PACKAGING.md))
+- Stevedores Nix cache (opt-in) for CI/local; Attic/R2 where applicable
 - Multi-environment promotion: dev → staging → prod
 - Flux/ArgoCD for GitOps deployment
 
@@ -426,6 +427,8 @@ Agent Decision Loop:
 
 ### 5.3 Deployment
 
+- [ ] Component images on GHCR (each repo: `flake.nix` + `dockworker.toml`, no Dockerfile)
+- [ ] OGRE `deploy/` mash-up Kustomize (pin component images + service URL ConfigMap)
 - [ ] Multi-environment rollout (dev → staging → prod)
 - [ ] Integration with lornu.ai agent swarm
 - [ ] Zero-Trust OIDC authentication
@@ -442,7 +445,7 @@ Agent Decision Loop:
 | **AST Parser** | tree-sitter vs syn | tree-sitter: multi-lang; syn: Rust-only |
 | **Codebase Indexing** | Pre-compute vs on-demand | Pre-compute: fast; on-demand: memory-efficient |
 | **Workflow Serialization** | TOML vs JSON | TOML: human-friendly; JSON: minimal |
-| **Isolation** | Containers vs seccomp | Containers: strong; seccomp: lightweight |
+| **Isolation** | Containers vs seccomp | OCI/Nix images (dockworker); seccomp optional in K8s |
 | **Knowledge Store** | SurrealDB vs PostgreSQL | SurrealDB: graph-native; PostgreSQL: proven |
 
 ---

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Enable autonomous code agents to be **productive, safe, and explainable** by arc
 
 Within the broader lornu.ai ecosystem for infrastructure automation.
 
+## 📦 Packaging & deploy
+
+- **No Dockerfiles** — OCI images from **Nix** flakes, published with **[dockworker.ai](https://dockworker.ai)** + skopeo (see [docs/PACKAGING.md](./docs/PACKAGING.md)).
+- **OGRE stack** — mash-up of component containers (oxidizedRAG + oxidizedgraph + data-fabric), not one fat image ([docs/DEPLOY_STACK.md](./docs/DEPLOY_STACK.md)).
+- **Kubernetes** — Kustomize overlays per component; OGRE will compose them when `deploy/` lands here.
+
 ## 📋 What's Here
 
 - **[PLAN.md](./PLAN.md)** - Integration wiring plan with 5 phases:

--- a/docs/DEPLOY_STACK.md
+++ b/docs/DEPLOY_STACK.md
@@ -1,0 +1,56 @@
+# OGRE deploy stack (component mash-up)
+
+OGRE production deploy is a **composition of component OCI images**, not a monolithic OGRE container.
+
+## Components
+
+| Service | Image (example) | Built in | Deploy manifests |
+|---------|-----------------|----------|------------------|
+| oxidizedgraph | `ghcr.io/stevedores-org/oxidizedgraph/server:<tag>` | [oxidizedgraph](https://github.com/stevedores-org/oxidizedgraph) — Nix + dockworker | `deploy/overlays/gke-autopilot` |
+| oxidizedRAG | TBD | [oxidizedRAG](https://github.com/stevedores-org/oxidizedRAG) | TBD (same pattern) |
+| data-fabric | per repo OCI docs | [data-fabric](https://github.com/stevedores-org/data-fabric) | TBD |
+
+Packaging rules: [PACKAGING.md](./PACKAGING.md) — **no Dockerfiles**, dockworker.ai + skopeo only.
+
+## OGRE repo (future)
+
+```
+ogre/deploy/
+  components/          # optional: remote bases or image pins
+  base/kustomization.yaml
+  overlays/gke-autopilot/
+```
+
+`ogre/deploy` will:
+
+1. Reference each component’s Kustomize overlay (or pinned `images:` transforms).
+2. Publish a shared ConfigMap for inter-service URLs.
+3. Add cross-namespace NetworkPolicy only where the stack requires it.
+
+OGRE does **not** add a fourth “fat” image unless a thin coordinator is needed later.
+
+## Service URL matrix (planned)
+
+```yaml
+# ogre deploy ConfigMap (illustrative)
+OXIDIZEDGRAPH_URL: "http://oxidizedgraph.oxidizedgraph.svc.cluster.local:8080"
+OXIDIZEDRAG_URL: "http://oxidizedrag.oxidizedrag.svc.cluster.local:8080"
+DATA_FABRIC_URL: "https://<fabric-host>/v1"
+```
+
+oxidizedgraph → data-fabric: graph execution events (`/v1/integrations/oxidizedgraph/events`).
+
+## Apply order (GKE Autopilot)
+
+```bash
+# Per component (from each repo, after dockworker push):
+kubectl apply -k deploy/overlays/gke-autopilot   # oxidizedgraph, etc.
+
+# Future: single entry from ogre
+kubectl apply -k ogre/deploy/overlays/gke-autopilot
+```
+
+## GitOps
+
+- **Kustomize + overlays** (no Helm), aligned with lornu.ai / stevedores GKE Autopilot conventions.
+- Image tags: semver or git SHA via dockworker / `IMAGE_TAG`; pin digest in overlay for prod.

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -1,0 +1,65 @@
+# Packaging (OGRE stack)
+
+**Org policy: no Dockerfiles.** Container images are **OCI-standard** artifacts built from **Nix** flakes and published with **[dockworker.ai](https://dockworker.ai)** + **skopeo**. Kubernetes deploys those images via **Kustomize** (no Helm).
+
+OGRE does not ship application binaries in this repo. Each component repo owns its image; OGRE composes them at deploy time.
+
+## Pipeline (per component repo)
+
+| Step | Tool | Output |
+|------|------|--------|
+| Build | `nix build .#<image-output>` | OCI tarball (`./result`) from `pkgs.dockerTools.buildLayeredImage` |
+| Manifest | `dockworker.toml` | Maps flake output → registry name/tag |
+| Push | `dockworker build` or `skopeo copy` | `ghcr.io/stevedores-org/<component>/...` |
+
+Example (oxidizedgraph):
+
+```bash
+nix build .#server-image -L
+dockworker build   # reads dockworker.toml, pushes via skopeo
+```
+
+## dockworker.toml
+
+Each service repo includes a `dockworker.toml` at the root:
+
+```toml
+version = 1
+flake = ".#"
+
+[[images]]
+name = "oxidizedgraph/server"
+nix_output = "server-image"
+push = true
+tag = "0.2.0"
+
+[registry]
+default = "ghcr.io/stevedores-org"
+
+[transport]
+tool = "skopeo"
+```
+
+dockworker.ai orchestrates `nix build` per `[[images]]` entry, then transports the tarball to the registry. No `docker build`, no Dockerfile.
+
+## Why no Dockerfiles
+
+- **Hermetic**: Nix owns deps; flakes are reproducible and cache-friendly (stevedores substituter opt-in — see component `docs/PACKAGING.md`).
+- **OCI without Docker**: Images are standard OCI layouts; runtime is containerd/CRI on GKE, not Docker Engine.
+- **Single source of truth**: `flake.nix` + `Cargo.lock` (for Rust) — no drift between Dockerfile layers and native builds.
+
+Legacy Dockerfiles in component repos (if any) are **deprecated** and must not be used for CI or production.
+
+## OGRE’s role
+
+| Repo | Builds image? | OGRE role |
+|------|---------------|-----------|
+| oxidizedgraph | Yes (`server-image`) | Wire URL + Kustomize component |
+| oxidizedRAG | Yes (when packaged) | Same |
+| data-fabric | Yes (OCI path per repo docs) | Same |
+| **ogre** | **No** | Stack Kustomize, contracts, env matrix — [DEPLOY_STACK.md](./DEPLOY_STACK.md) |
+
+## References
+
+- [oxidizedgraph — PACKAGING](https://github.com/stevedores-org/oxidizedgraph/blob/main/docs/PACKAGING.md) (once merged)
+- [lornu-finops — PACKAGING](https://github.com/lornu-ai/lornu-finops/blob/main/docs/PACKAGING.md) (reference pattern)


### PR DESCRIPTION
## Summary

- Document **org packaging policy**: no Dockerfiles; OCI images from **Nix** (`flake.nix`) published via **[dockworker.ai](https://dockworker.ai)** + **skopeo**
- Define **OGRE deploy model** as a mash-up of component containers (oxidizedRAG, oxidizedgraph, data-fabric), not a monolithic OGRE image
- Update `README.md` and `PLAN.md` Phase 5.3 checklist accordingly

## Files

| Doc | Purpose |
|-----|---------|
| `docs/PACKAGING.md` | Nix → OCI → dockworker.toml → GHCR |
| `docs/DEPLOY_STACK.md` | Component URLs, apply order, future `ogre/deploy/` |

## Test plan

### This PR (docs only)

- [x] Pre-commit hook passes
- [x] Links and paths render in GitHub

### Next: K8s validation (follow-up work, not blocked on this PR)

Prerequisite: [oxidizedgraph#44](https://github.com/stevedores-org/oxidizedgraph/pull/44) merged + image pushed to GHCR.

1. **oxidizedgraph** (first component)
   ```bash
   cd oxidizedgraph
   just image && IMAGE_TAG=0.2.0 just push   # GHCR auth
   # Edit deploy/overlays/gke-autopilot/serviceaccount-wi.yaml
   kubectl apply -k deploy/overlays/gke-autopilot
   kubectl -n oxidizedgraph get pods,svc,pdb
   kubectl -n oxidizedgraph port-forward svc/oxidizedgraph 8080:8080
   curl -s http://localhost:8080/health
   ```

2. **OGRE stack** (after `ogre/deploy/` lands)
   - Apply component overlays in order (graph → rag → fabric)
   - Verify cross-namespace egress (fabric HTTPS, graph → fabric events)
   - Smoke: PR-reviewer-style flow (retrieve → execute → persist)

3. **Track in ogre**
   - [ ] Open issue: `deploy/base` Kustomize mash-up + GKE Autopilot overlay
   - [ ] Pin component image digests in overlay after first successful cluster apply


Made with [Cursor](https://cursor.com)