### PR TITLE
fix(cargo): use relative sibling paths for oxidizedgraph and graphrag-core dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ serde_json = "1.0"
 thiserror = "1.0"
 async-trait = "0.1"
 uuid = { version = "1.0", features = ["v4", "serde"] }
-oxidizedgraph = { path = "/Users/aivcs/engineering/code/oxidizedgraph" }
-graphrag-core = { path = "/Users/aivcs/engineering/code/oxidizedRAG/graphrag-core" }
+oxidizedgraph = { path = "../oxidizedgraph" }
+graphrag-core = { path = "../oxidizedRAG/graphrag-core" }
 chrono = { version = "0.4", features = ["serde"] }
 ogre-core = { path = "crates/ogre-core" }
 ogre-retrieval = { path = "crates/ogre-retrieval" }


### PR DESCRIPTION
This PR fixes a critical compilation issue where the root Cargo.toml referenced dependencies using hardcoded absolute paths in the /Users/aivcs/ directory. It replaces them with relative paths pointing to sibling checkouts.